### PR TITLE
Extended start script extension improvements

### DIFF
--- a/priv/templates/extended_bin
+++ b/priv/templates/extended_bin
@@ -542,9 +542,9 @@ relx_run_extension() {
     EXTENSION_SCRIPT=$1
     shift
     # all extension script locations are expected to be
-    # relative to the start script location
+    # relative to the release root
     # shellcheck disable=SC1090,SC2240
-    [ -f "$SCRIPT_DIR/$EXTENSION_SCRIPT" ] && . "$SCRIPT_DIR/$EXTENSION_SCRIPT" "$@"
+    [ -f "$RELEASE_ROOT_DIR/$EXTENSION_SCRIPT" ] && . "$RELEASE_ROOT_DIR/$EXTENSION_SCRIPT" "$@"
 }
 
 # given a list of arguments, identify the internal ones

--- a/shelltests/extension_tests/rebar.config
+++ b/shelltests/extension_tests/rebar.config
@@ -3,10 +3,9 @@
 
 {relx, [{release, {extension_tests, "0.1.0"},
          [extension_tests]},
-        {extended_start_script_extensions, [{bar, "extensions/bar"},
-                                            {foo, "extensions/foo"},
-                                            {baz, "extensions/baz"}]},
-        {overlay, [{copy, "./bar", "bin/extensions/bar"},
-                   {copy, "./foo", "bin/extensions/foo"},
-                   {copy, "./baz", "bin/extensions/baz"}]}
+        {extended_start_script_extensions, [
+            {bar, "./bar"},
+            {foo, "./foo"},
+            {baz, "./baz"}
+        ]}
 ]}.

--- a/shelltests/extension_tests/rebar.config
+++ b/shelltests/extension_tests/rebar.config
@@ -5,7 +5,7 @@
          [extension_tests]},
         {extended_start_script_extensions, [
             {bar, "./bar"},
-            {foo, "./foo"},
-            {baz, "./baz"}
+            {foo, "./foo", "foo description"},
+            {baz, "./baz", "bin/extensions/baz", "baz description"}
         ]}
 ]}.


### PR DESCRIPTION
Format of `extended_start_script_extensions` is no longer `{name, target}`
and now becomes one of:
  `{name, src}`
  `{name, src, description}`
  `{name, src, target, description}`